### PR TITLE
YAPF Integration

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -8,28 +8,32 @@ from translate import *
 from purge import *
 from poll import *
 
-commands_list = ["hello", "play", "disconnect", "purge", "translate", "poll", "coinflip"]
+commands_list = ["hello", "play", "disconnect",
+                 "purge", "translate", "poll", "coinflip", "lint"]
+
 
 class Command():
 
-	def __init__(self, client, message, command, params):
-		self.client = client
-		self.message = message
-		self.command = command
-		self.params = params
+    def __init__(self, client, message, command, params):
+        self.client = client
+        self.message = message
+        self.command = command
+        self.params = params
 
-	async def execute(self):
-		if self.command == "hello":
-			await hello(self.client, self.message)
-		if self.command == "play":
-			await play(self.client, self.message, self.params)
-		if self.command == "disconnect":
-			await disconnect(self.client, self.message)
-		if self.command == "translate":
-			await translate(self.client, self.message, self.params)
-		if self.command == "purge":
-			await purge(self.client, self.message, self.params)
-		if self.command == "poll":
-			await poll(self.client, self.message, self.params)
-		if self.command == "coinflip":
-			await coinflip(self.client, self.message)
+    async def execute(self):
+        if self.command == "hello":
+            await hello(self.client, self.message)
+        if self.command == "play":
+            await play(self.client, self.message, self.params)
+        if self.command == "disconnect":
+            await disconnect(self.client, self.message)
+        if self.command == "translate":
+            await translate(self.client, self.message, self.params)
+        if self.command == "purge":
+            await purge(self.client, self.message, self.params)
+        if self.command == "poll":
+            await poll(self.client, self.message, self.params)
+        if self.command == "coinflip":
+            await coinflip(self.client, self.message)
+        if self.command == "lint":
+            await lint(self.client, self.message, self.params)

--- a/commands.py
+++ b/commands.py
@@ -7,6 +7,7 @@ from disconnect import *
 from translate import *
 from purge import *
 from poll import *
+from lint import *
 
 commands_list = ["hello", "play", "disconnect",
                  "purge", "translate", "poll", "coinflip", "lint"]

--- a/commands/lint.py
+++ b/commands/lint.py
@@ -3,12 +3,24 @@ import re
 
 
 async def lint(client, message, params):
-    if(re.match("(?<=(```py\n))(.*)(?=(\n```))", params)):
-        code = re.sub("(?<=(```py\n))(.*)(?=(\n```))", '',
-                      params)  # removes code header tags
-        # uses yapf to format w/ pep8 linter
-        formatted = FormatCode(code, style_config='pep8')
-        await client.send_message("```py\n" + formatted + "\n```")
+    # Turns the param list into one long string
+    code_line = message.content
+
+    # Regex pattern searches for code
+    regex = r"((?<=(```py\s))|(?<=(```python\s)))([\s\S]*)(?=(\s```))"
+
+    # Checks for regex match(if code is surrounded by ```py ``` or ```python ```)
+    if(re.search(regex, code_line)):
+        # Group 4 is what the code is, other groups contain the header tags.
+        code = re.search(regex, code_line).group(4)
+        # Uses yapf to format w/ pep8 linter
+        try:
+            formatted = FormatCode(code, style_config='pep8')
+            await client.send_message(message.channel, "```py\n" + formatted[0] + "\n```")
+        except:
+            await client.send_message(message.channel, "Error in code.")
+
     else:
-        # keep the language SPICY
+        # Invalid code
         await client.send_message(message.channel, "Invalid code, buckeroo!")
+        print(code_line)

--- a/commands/lint.py
+++ b/commands/lint.py
@@ -1,0 +1,14 @@
+from yapf.yapflib.yapf_api import FormatCode
+import re
+
+
+async def lint(client, message, params):
+    if(re.match("(?<=(```py\n))(.*)(?=(\n```))", params)):
+        code = re.sub("(?<=(```py\n))(.*)(?=(\n```))", '',
+                      params)  # removes code header tags
+        # uses yapf to format w/ pep8 linter
+        formatted = FormatCode(code, style_config='pep8')
+        await client.send_message("```py\n" + formatted + "\n```")
+    else:
+        # keep the language SPICY
+        await client.send_message(message.channel, "Invalid code, buckeroo!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ discord.py
 googletrans
 libopus
 ffmpeg
+yapf
 	- see Gorialis's comment on https://github.com/Rapptz/discord.py/issues/1149 for help in setting up PATH environement for ffmpeg
 youtube-dl
 googletrans

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ discord.py
 googletrans
 libopus
 ffmpeg
-yapf
 	- see Gorialis's comment on https://github.com/Rapptz/discord.py/issues/1149 for help in setting up PATH environement for ffmpeg
-youtube-dl
+youtube_dl
 googletrans
+yapf


### PR DESCRIPTION
# Description
With the !lint command, the bot will now be able to format python code. YAPF, an open-source library by Google, works similarly to Beautify.js. It will not fix code, although that could be added to the !lint command in the future.

The command uses a regex filter to pull the code from Discord's code highlighting headers, and it then passes the code to the YAPF Formatter. If the code is invalid (not formatted correctly in Discord), the bot will tell the user that the code is invalid. If there is an error, the bot will inform the user that there is an error in the code.

# How To Use
`````
!lint ```py
<code>
```
`````
**OR**
`````
!lint ```python
<code>
```
`````